### PR TITLE
Remove `name` claim from `username` of `runtime:Principal`

### DIFF
--- a/jwt-ballerina/src/jwt/inbound_jwt_auth_provider.bal
+++ b/jwt-ballerina/src/jwt/inbound_jwt_auth_provider.bal
@@ -86,11 +86,5 @@ function setPrincipal(JwtPayload jwtPayload) {
                 auth:setPrincipal(scopes = stringutils:split(scopeString, " "));
             }
         }
-        if (claims.hasKey("name")) {
-            json name = claims["name"];
-            if (name is string) {
-                auth:setPrincipal(username = name);
-            }
-        }
     }
 }


### PR DESCRIPTION
## Purpose
This PR removes the `name` claim adding as the `username` of `runtime:Principal` record once authenticated.