### PR TITLE
Append JWT mandatory parameters as custom claims

### DIFF
--- a/jwt-ballerina/src/jwt/jwt_validator.bal
+++ b/jwt-ballerina/src/jwt/jwt_validator.bal
@@ -219,19 +219,19 @@ function parsePayload(map<json> jwtPayloadJson) returns JwtPayload|Error {
         match (key) {
             ISS => {
                 jwtPayload.iss = jwtPayloadJson[key].toJsonString();
-                customClaims[ISS] = jwtPayload.iss;
+                customClaims[ISS] = jwtPayload?.iss;
             }
             SUB => {
                 jwtPayload.sub = jwtPayloadJson[key].toJsonString();
-                customClaims[SUB] = jwtPayload.sub;
+                customClaims[SUB] = jwtPayload?.sub;
             }
             AUD => {
                 jwtPayload.aud = check convertToStringArray(jwtPayloadJson[key]);
-                customClaims[AUD] = jwtPayload.aud;
+                customClaims[AUD] = jwtPayload?.aud;
             }
             JTI => {
                 jwtPayload.jti = jwtPayloadJson[key].toJsonString();
-                customClaims[JTI] = jwtPayload.jti;
+                customClaims[JTI] = jwtPayload?.jti;
             }
             EXP => {
                 string exp = jwtPayloadJson[key].toJsonString();

--- a/jwt-ballerina/src/jwt/jwt_validator.bal
+++ b/jwt-ballerina/src/jwt/jwt_validator.bal
@@ -219,18 +219,23 @@ function parsePayload(map<json> jwtPayloadJson) returns JwtPayload|Error {
         match (key) {
             ISS => {
                 jwtPayload.iss = jwtPayloadJson[key].toJsonString();
+                customClaims[ISS] = jwtPayload.iss;
             }
             SUB => {
                 jwtPayload.sub = jwtPayloadJson[key].toJsonString();
+                customClaims[SUB] = jwtPayload.sub;
             }
             AUD => {
                 jwtPayload.aud = check convertToStringArray(jwtPayloadJson[key]);
+                customClaims[AUD] = jwtPayload.aud;
             }
             JTI => {
                 jwtPayload.jti = jwtPayloadJson[key].toJsonString();
+                customClaims[JTI] = jwtPayload.jti;
             }
             EXP => {
                 string exp = jwtPayloadJson[key].toJsonString();
+                customClaims[EXP] = exp;
                 int|error value = langint:fromString(exp);
                 if (value is int) {
                     jwtPayload.exp = value;
@@ -240,6 +245,7 @@ function parsePayload(map<json> jwtPayloadJson) returns JwtPayload|Error {
             }
             NBF => {
                 string nbf = jwtPayloadJson[key].toJsonString();
+                customClaims[NBF] = nbf;
                 int|error value = langint:fromString(nbf);
                 if (value is int) {
                     jwtPayload.nbf = value;
@@ -249,6 +255,7 @@ function parsePayload(map<json> jwtPayloadJson) returns JwtPayload|Error {
             }
             IAT => {
                 string iat = jwtPayloadJson[key].toJsonString();
+                customClaims[IAT] = iat;
                 int|error value = langint:fromString(iat);
                 if (value is int) {
                     jwtPayload.iat = value;


### PR DESCRIPTION
## Purpose
This PR appends JWT mandatory parameters as custom claims. Then those parameters can be retrieved from `runtime:InvocationContext` once inbound authentication got succeeded.