### PR TITLE
Replace HTTP dependency with JDK11 HTTP client

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,7 @@ ext.stdlibTimeVersion = project.stdlibTimeVersion
 ext.stdlibSystemVersion = project.stdlibSystemVersion
 ext.stdlibConfigVersion = project.stdlibConfigVersion
 ext.stdlibTaskVersion = project.stdlibTaskVersion
+ext.stdlibRuntimeVersion = project.stdlibRuntimeVersion
 
 allprojects {
     group = project.group
@@ -152,6 +153,14 @@ allprojects {
                 password System.getenv("packagePAT")
             }
         }
+
+        maven {
+            url = 'https://maven.pkg.github.com/ballerina-platform/module-ballerina-runtime'
+            credentials {
+                username System.getenv("packageUser")
+                password System.getenv("packagePAT")
+            }
+        }
     }
 }
 
@@ -174,6 +183,7 @@ subprojects {
         ballerinaStdLibs "org.ballerinalang:system-ballerina:${stdlibSystemVersion}"
         ballerinaStdLibs "org.ballerinalang:config-ballerina:${stdlibConfigVersion}"
         ballerinaStdLibs "org.ballerinalang:task-ballerina:${stdlibTaskVersion}"
+        ballerinaStdLibs "org.ballerinalang:runtime-ballerina:${stdlibRuntimeVersion}"
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,6 @@ plugins {
 ext.ballerinaLangVersion = project.ballerinaLangVersion
 ext.stdlibAuthVersion = project.stdlibAuthVersion
 ext.stdlibCacheVersion = project.stdlibCacheVersion
-ext.stdlibHttpVersion = project.stdlibHttpVersion
 ext.stdlibStringUtilsVersion = project.stdlibStringUtilsVersion
 ext.stdlibLogVersion = project.stdlibLogVersion
 ext.stdlibCryptoVersion = project.stdlibCryptoVersion
@@ -36,9 +35,6 @@ ext.stdlibTimeVersion = project.stdlibTimeVersion
 ext.stdlibSystemVersion = project.stdlibSystemVersion
 ext.stdlibConfigVersion = project.stdlibConfigVersion
 ext.stdlibTaskVersion = project.stdlibTaskVersion
-ext.stdlibReflectVersion = project.stdlibReflectVersion
-ext.stdlibMimeVersion = project.stdlibMimeVersion
-ext.stdlibRuntimeVersion = project.stdlibRuntimeVersion
 
 allprojects {
     group = project.group
@@ -79,14 +75,6 @@ allprojects {
 
         maven {
             url = 'https://maven.pkg.github.com/ballerina-platform/module-ballerina-cache'
-            credentials {
-                username System.getenv("packageUser")
-                password System.getenv("packagePAT")
-            }
-        }
-
-        maven {
-            url = 'https://maven.pkg.github.com/ballerina-platform/module-ballerina-http'
             credentials {
                 username System.getenv("packageUser")
                 password System.getenv("packagePAT")
@@ -164,38 +152,6 @@ allprojects {
                 password System.getenv("packagePAT")
             }
         }
-
-        maven {
-            url = 'https://maven.pkg.github.com/ballerina-platform/module-ballerina-reflect'
-            credentials {
-                username System.getenv("packageUser")
-                password System.getenv("packagePAT")
-            }
-        }
-
-        maven {
-            url = 'https://maven.pkg.github.com/ballerina-platform/module-ballerina-file'
-            credentials {
-                username System.getenv("packageUser")
-                password System.getenv("packagePAT")
-            }
-        }
-
-        maven {
-            url = 'https://maven.pkg.github.com/ballerina-platform/module-ballerina-mime'
-            credentials {
-                username System.getenv("packageUser")
-                password System.getenv("packagePAT")
-            }
-        }
-
-        maven {
-            url = 'https://maven.pkg.github.com/ballerina-platform/module-ballerina-runtime'
-            credentials {
-                username System.getenv("packageUser")
-                password System.getenv("packagePAT")
-            }
-        }
     }
 }
 
@@ -209,7 +165,6 @@ subprojects {
         /* Standard libraries */
         ballerinaStdLibs "org.ballerinalang:auth-ballerina:${stdlibAuthVersion}"
         ballerinaStdLibs "org.ballerinalang:cache-ballerina:${stdlibCacheVersion}"
-        ballerinaStdLibs "org.ballerinalang:http-ballerina:${stdlibHttpVersion}"
         ballerinaStdLibs "org.ballerinalang:stringutils-ballerina:${stdlibStringUtilsVersion}"
         ballerinaStdLibs "org.ballerinalang:log-ballerina:${stdlibLogVersion}"
         ballerinaStdLibs "org.ballerinalang:crypto-ballerina:${stdlibCryptoVersion}"
@@ -219,10 +174,6 @@ subprojects {
         ballerinaStdLibs "org.ballerinalang:system-ballerina:${stdlibSystemVersion}"
         ballerinaStdLibs "org.ballerinalang:config-ballerina:${stdlibConfigVersion}"
         ballerinaStdLibs "org.ballerinalang:task-ballerina:${stdlibTaskVersion}"
-        ballerinaStdLibs "org.ballerinalang:reflect-ballerina:${stdlibReflectVersion}"
-        ballerinaStdLibs "org.ballerinalang:file-ballerina:${stdlibFileVersion}"
-        ballerinaStdLibs "org.ballerinalang:mime-ballerina:${stdlibMimeVersion}"
-        ballerinaStdLibs "org.ballerinalang:runtime-ballerina:${stdlibRuntimeVersion}"
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,6 @@ org.gradle.caching=true
 group=org.ballerinalang
 version=1.0.4-SNAPSHOT
 ballerinaLangVersion=2.0.0-Preview6-SNAPSHOT
-# Direct Dependencies
 stdlibAuthVersion=1.0.2-SNAPSHOT
 stdlibCacheVersion=2.0.2-SNAPSHOT
 stdlibStringUtilsVersion=0.5.2-SNAPSHOT
@@ -12,12 +11,5 @@ stdlibEncodingVersion=1.0.4-SNAPSHOT
 stdlibIoVersion=0.5.2-SNAPSHOT
 stdlibTimeVersion=1.0.3-SNAPSHOT
 stdlibSystemVersion=0.6.2-SNAPSHOT
-# Transitive Dependencies
 stdlibConfigVersion=1.0.2-SNAPSHOT
 stdlibTaskVersion=1.1.2-SNAPSHOT
-
-#stdlibHttpVersion=1.0.2-SNAPSHOT
-#stdlibRuntimeVersion=0.5.2-SNAPSHOT
-#stdlibFileVersion=0.5.3-SNAPSHOT
-#stdlibMimeVersion=1.0.2-SNAPSHOT
-#stdlibReflectVersion=0.5.2-SNAPSHOT

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,3 +13,4 @@ stdlibTimeVersion=1.0.3-SNAPSHOT
 stdlibSystemVersion=0.6.2-SNAPSHOT
 stdlibConfigVersion=1.0.2-SNAPSHOT
 stdlibTaskVersion=1.1.2-SNAPSHOT
+stdlibRuntimeVersion=0.5.2-SNAPSHOT

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,9 +2,9 @@ org.gradle.caching=true
 group=org.ballerinalang
 version=1.0.4-SNAPSHOT
 ballerinaLangVersion=2.0.0-Preview6-SNAPSHOT
+# Direct Dependencies
 stdlibAuthVersion=1.0.2-SNAPSHOT
 stdlibCacheVersion=2.0.2-SNAPSHOT
-stdlibHttpVersion=1.0.2-SNAPSHOT
 stdlibStringUtilsVersion=0.5.2-SNAPSHOT
 stdlibLogVersion=1.0.2-SNAPSHOT
 stdlibCryptoVersion=1.0.2-SNAPSHOT
@@ -12,9 +12,12 @@ stdlibEncodingVersion=1.0.4-SNAPSHOT
 stdlibIoVersion=0.5.2-SNAPSHOT
 stdlibTimeVersion=1.0.3-SNAPSHOT
 stdlibSystemVersion=0.6.2-SNAPSHOT
+# Transitive Dependencies
 stdlibConfigVersion=1.0.2-SNAPSHOT
 stdlibTaskVersion=1.1.2-SNAPSHOT
-stdlibReflectVersion=0.5.2-SNAPSHOT
-stdlibFileVersion=0.5.3-SNAPSHOT
-stdlibMimeVersion=1.0.2-SNAPSHOT
-stdlibRuntimeVersion=0.5.2-SNAPSHOT
+
+#stdlibHttpVersion=1.0.2-SNAPSHOT
+#stdlibRuntimeVersion=0.5.2-SNAPSHOT
+#stdlibFileVersion=0.5.3-SNAPSHOT
+#stdlibMimeVersion=1.0.2-SNAPSHOT
+#stdlibReflectVersion=0.5.2-SNAPSHOT

--- a/jwt-ballerina/Ballerina.toml
+++ b/jwt-ballerina/Ballerina.toml
@@ -19,3 +19,13 @@ version = "@toml.version@"
 "ballerina/file" = "@stdlib.file.version@"
 "ballerina/mime" = "@stdlib.mime.version@"
 "ballerina/runtime" = "@stdlib.runtime.version@"
+
+[platform]
+target = "java11"
+
+    [[platform.libraries]]
+    artifactId = "jwt"
+    version = "@project.version@"
+    path = "../jwt-native/build/libs/jwt-native-@project.version@.jar"
+    groupId = "ballerina"
+    modules = ["jwt"]

--- a/jwt-ballerina/Ballerina.toml
+++ b/jwt-ballerina/Ballerina.toml
@@ -5,7 +5,6 @@ version = "@toml.version@"
 [dependencies]
 "ballerina/auth" = "@stdlib.auth.version@"
 "ballerina/cache" = "@stdlib.cache.version@"
-"ballerina/http" = "@stdlib.http.version@"
 "ballerina/stringutils" = "@stdlib.stringutils.version@"
 "ballerina/log" = "@stdlib.log.version@"
 "ballerina/crypto" = "@stdlib.crypto.version@"
@@ -15,10 +14,6 @@ version = "@toml.version@"
 "ballerina/system" = "@stdlib.system.version@"
 "ballerina/config" = "@stdlib.config.version@"
 "ballerina/task" = "@stdlib.task.version@"
-"ballerina/reflect" = "@stdlib.reflect.version@"
-"ballerina/file" = "@stdlib.file.version@"
-"ballerina/mime" = "@stdlib.mime.version@"
-"ballerina/runtime" = "@stdlib.runtime.version@"
 
 [platform]
 target = "java11"

--- a/jwt-ballerina/Ballerina.toml
+++ b/jwt-ballerina/Ballerina.toml
@@ -14,6 +14,7 @@ version = "@toml.version@"
 "ballerina/system" = "@stdlib.system.version@"
 "ballerina/config" = "@stdlib.config.version@"
 "ballerina/task" = "@stdlib.task.version@"
+"ballerina/runtime" = "@stdlib.runtime.version@"
 
 [platform]
 target = "java11"

--- a/jwt-ballerina/build.gradle
+++ b/jwt-ballerina/build.gradle
@@ -16,6 +16,10 @@
  * under the License.
  */
 
+plugins {
+    id 'java'
+}
+
 import org.apache.tools.ant.taskdefs.condition.Os
 
 description = 'Ballerina - JWT Ballerina Generator'
@@ -107,7 +111,6 @@ task updateTomlVersions {
     doLast {
         def stdlibDependentAuthVersion = project.stdlibAuthVersion.split("-")[0]
         def stdlibDependentCacheVersion = project.stdlibCacheVersion.split("-")[0]
-        def stdlibDependentHttpVersion = project.stdlibHttpVersion.split("-")[0]
         def stdlibDependentStringUtilsVersion = project.stdlibStringUtilsVersion.split("-")[0]
         def stdlibDependentLogVersion = project.stdlibLogVersion.split("-")[0]
         def stdlibDependentCryptoVersion = project.stdlibCryptoVersion.split("-")[0]
@@ -117,16 +120,11 @@ task updateTomlVersions {
         def stdlibDependentSystemVersion = project.stdlibSystemVersion.split("-")[0]
         def stdlibDependentConfigVersion = project.stdlibConfigVersion.split("-")[0]
         def stdlibDependentTaskVersion = project.stdlibTaskVersion.split("-")[0]
-        def stdlibDependentReflectVersion = project.stdlibReflectVersion.split("-")[0]
-        def stdlibDependentFileVersion = project.stdlibFileVersion.split("-")[0]
-        def stdlibDependentMimeVersion = project.stdlibMimeVersion.split("-")[0]
-        def stdlibDependentRuntimeVersion = project.stdlibRuntimeVersion.split("-")[0]
 
         def newConfig = ballerinaConfigFile.text.replace("@project.version@", project.version)
         newConfig = newConfig.replace("@toml.version@", tomlVersion)
         newConfig = newConfig.replace("@stdlib.auth.version@", stdlibDependentAuthVersion)
         newConfig = newConfig.replace("@stdlib.cache.version@", stdlibDependentCacheVersion)
-        newConfig = newConfig.replace("@stdlib.http.version@", stdlibDependentHttpVersion)
         newConfig = newConfig.replace("@stdlib.stringutils.version@", stdlibDependentStringUtilsVersion)
         newConfig = newConfig.replace("@stdlib.log.version@", stdlibDependentLogVersion)
         newConfig = newConfig.replace("@stdlib.crypto.version@", stdlibDependentCryptoVersion)
@@ -136,10 +134,6 @@ task updateTomlVersions {
         newConfig = newConfig.replace("@stdlib.system.version@", stdlibDependentSystemVersion)
         newConfig = newConfig.replace("@stdlib.config.version@", stdlibDependentConfigVersion)
         newConfig = newConfig.replace("@stdlib.task.version@", stdlibDependentTaskVersion)
-        newConfig = newConfig.replace("@stdlib.reflect.version@", stdlibDependentReflectVersion)
-        newConfig = newConfig.replace("@stdlib.file.version@", stdlibDependentFileVersion)
-        newConfig = newConfig.replace("@stdlib.mime.version@", stdlibDependentMimeVersion)
-        newConfig = newConfig.replace("@stdlib.runtime.version@", stdlibDependentRuntimeVersion)
         ballerinaConfigFile.text = newConfig
     }
 }

--- a/jwt-ballerina/build.gradle
+++ b/jwt-ballerina/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     jbalTools ("org.ballerinalang:jballerina-tools:${ballerinaLangVersion}") {
         transitive = false
     }
+    compile project(':jwt-native')
 }
 
 clean {
@@ -99,6 +100,7 @@ def artifactLibParent = file("$project.projectDir/build/lib_parent/")
 def tomlVersion = project.version.split("-")[0]
 def ballerinaCentralAccessToken = System.getenv('BALLERINA_CENTRAL_ACCESS_TOKEN')
 def targetBallerinaJar = file("$project.projectDir/target/caches/jar_cache/${moduleOrg}/${moduleName}/${tomlVersion}/${moduleOrg}-${moduleName}-${tomlVersion}.jar")
+def targetNativeJar = file("$project.rootDir/${moduleName}-native/build/libs/${moduleName}-native-${project.version}.jar")
 def originalConfig = ballerinaConfigFile.text
 
 task updateTomlVersions {
@@ -150,6 +152,7 @@ task revertTomlFile {
 
 task ballerinaTest {
     dependsOn(copyStdlibs)
+    dependsOn(":jwt-native:build")
     dependsOn(updateTomlVersions)
     finalizedBy(revertTomlFile)
 
@@ -224,6 +227,11 @@ task ballerinaBuild {
             into file("$artifactLibParent/libs")
         }
 
+        copy {
+            from targetNativeJar
+            into file("$artifactLibParent/libs")
+        }
+
         // Publish to central
         if (!project.version.endsWith('-SNAPSHOT') && ballerinaCentralAccessToken != null && project.hasProperty("publishToCentral")) {
             println("Publishing to the ballerina central..")
@@ -282,6 +290,7 @@ publishing {
     }
 }
 
+ballerinaBuild.dependsOn ":jwt-native:build"
 unpackStdLibs.dependsOn unpackJballerinaTools
 copyStdlibs.dependsOn unpackStdLibs
 updateTomlVersions.dependsOn copyStdlibs

--- a/jwt-ballerina/build.gradle
+++ b/jwt-ballerina/build.gradle
@@ -120,6 +120,7 @@ task updateTomlVersions {
         def stdlibDependentSystemVersion = project.stdlibSystemVersion.split("-")[0]
         def stdlibDependentConfigVersion = project.stdlibConfigVersion.split("-")[0]
         def stdlibDependentTaskVersion = project.stdlibTaskVersion.split("-")[0]
+        def stdlibDependentRuntimeVersion = project.stdlibRuntimeVersion.split("-")[0]
 
         def newConfig = ballerinaConfigFile.text.replace("@project.version@", project.version)
         newConfig = newConfig.replace("@toml.version@", tomlVersion)
@@ -134,6 +135,7 @@ task updateTomlVersions {
         newConfig = newConfig.replace("@stdlib.system.version@", stdlibDependentSystemVersion)
         newConfig = newConfig.replace("@stdlib.config.version@", stdlibDependentConfigVersion)
         newConfig = newConfig.replace("@stdlib.task.version@", stdlibDependentTaskVersion)
+        newConfig = newConfig.replace("@stdlib.runtime.version@", stdlibDependentRuntimeVersion)
         ballerinaConfigFile.text = newConfig
     }
 }

--- a/jwt-ballerina/src/jwt/inbound_jwt_auth_provider.bal
+++ b/jwt-ballerina/src/jwt/inbound_jwt_auth_provider.bal
@@ -82,7 +82,7 @@ public class InboundJwtAuthProvider {
 
 isolated function preloadJwksToCache(JwksConfig jwksConfig) returns @tainted Error? {
     cache:Cache jwksCache = <cache:Cache>jwksConfig?.jwksCache;
-    string|Error stringResponse = getJwksResponse(jwksConfig.url);
+    string|Error stringResponse = getJwksResponse(jwksConfig.url, jwksConfig.clientConfig);
     if (stringResponse is Error) {
         return prepareError("Failed to call JWKs endpoint to preload JWKs to the cache.", stringResponse);
     }

--- a/jwt-ballerina/src/jwt/inbound_jwt_auth_provider.bal
+++ b/jwt-ballerina/src/jwt/inbound_jwt_auth_provider.bal
@@ -80,7 +80,7 @@ public class InboundJwtAuthProvider {
     }
 }
 
-isolated function preloadJwksToCache(JwksConfig jwksConfig) returns @tainted Error? {
+isolated function preloadJwksToCache(JwksConfig jwksConfig) returns Error? {
     cache:Cache jwksCache = <cache:Cache>jwksConfig?.jwksCache;
     string|Error stringResponse = getJwksResponse(jwksConfig.url, jwksConfig.clientConfig);
     if (stringResponse is Error) {

--- a/jwt-ballerina/src/jwt/jwt_errors.bal
+++ b/jwt-ballerina/src/jwt/jwt_errors.bal
@@ -18,11 +18,11 @@ import ballerina/auth;
 import ballerina/log;
 
 # Represents the JWT distinct error
-public type JWTError distinct error;
+public type JwtError distinct error;
 
 # Represents the JWT error type with details. This will be returned if an error occurred while issuing/validating a
 # JWT or any operation related to JWT.
-public type Error JWTError;
+public type Error JwtError;
 
 # Logs and prepares the `error` as an `Error`.
 #
@@ -33,9 +33,9 @@ isolated function prepareError(string message, error? err = ()) returns Error {
     log:printError(message, err);
     Error jwtError;
     if (err is error) {
-        jwtError = JWTError(message, err);
+        jwtError = JwtError(message, err);
     } else {
-        jwtError = JWTError(message);
+        jwtError = JwtError(message);
     }
     return jwtError;
 }

--- a/jwt-ballerina/src/jwt/jwt_validator.bal
+++ b/jwt-ballerina/src/jwt/jwt_validator.bal
@@ -94,7 +94,7 @@ public type JwtTrustStoreConfig record {|
 # + jwt - JWT that needs to be validated
 # + config - JWT validator config record
 # + return - JWT payload or else a `jwt:Error` if token validation fails
-public function validateJwt(string jwt, @tainted JwtValidatorConfig config) returns @tainted (JwtPayload|Error) {
+public function validateJwt(string jwt, JwtValidatorConfig config) returns @tainted (JwtPayload|Error) {
     if (config.jwtCache.hasKey(jwt)) {
         JwtPayload? payload = validateFromCache(config.jwtCache, jwt);
         if (payload is JwtPayload) {
@@ -303,7 +303,7 @@ isolated function parsePayload(map<json> jwtPayloadJson) returns JwtPayload|Erro
 }
 
 isolated function validateJwtRecords(string jwt, JwtHeader jwtHeader, JwtPayload jwtPayload, JwtValidatorConfig config)
-                                     returns @tainted Error? {
+                                     returns Error? {
     if (!validateMandatoryJwtHeaderFields(jwtHeader)) {
         return prepareError("Mandatory field signing algorithm (alg) is not provided in JOSE header.");
     }
@@ -389,7 +389,7 @@ isolated function validateSignatureByTrustStore(string jwt, JwtSigningAlgorithm 
 }
 
 isolated function validateSignatureByJwks(string jwt, string kid, JwtSigningAlgorithm alg, JwksConfig jwksConfig)
-                                          returns @tainted Error? {
+                                          returns Error? {
     json jwk = check getJwk(kid, jwksConfig);
     if (jwk is ()) {
         return prepareError("No JWK found for kid: " + kid);
@@ -424,7 +424,7 @@ isolated function validateSignature(string jwt, JwtSigningAlgorithm alg, crypto:
     }
 }
 
-isolated function getJwk(string kid, JwksConfig jwksConfig) returns @tainted (json|Error) {
+isolated function getJwk(string kid, JwksConfig jwksConfig) returns json|Error {
     cache:Cache? jwksCache = jwksConfig?.jwksCache;
     if (jwksCache is cache:Cache) {
         if (jwksCache.hasKey(kid)) {

--- a/jwt-ballerina/src/jwt/jwt_validator.bal
+++ b/jwt-ballerina/src/jwt/jwt_validator.bal
@@ -110,17 +110,18 @@ public function validateJwt(string jwt, @tainted JwtValidatorConfig config) retu
 isolated function validateFromCache(cache:Cache jwtCache, string jwt) returns JwtPayload? {
     JwtPayload payload = <JwtPayload>jwtCache.get(jwt);
     int? expTime = payload?.exp;
+    final string jwtPayload = payload.toString();
     // convert to current time and check the expiry time
     if (expTime is () || expTime > (time:currentTime().time / 1000)) {
-        log:printDebug(function() returns string {
-            return "JWT validated from the cache. JWT payload: " + payload.toString();
+        log:printDebug(isolated function() returns string {
+            return "JWT validated from the cache. JWT payload: " + jwtPayload;
         });
         return payload;
     } else {
         cache:Error? result = jwtCache.invalidate(jwt);
         if (result is cache:Error) {
-            log:printDebug(function() returns string {
-                return "Failed to invalidate JWT from the cache. JWT payload: " + payload.toString();
+            log:printDebug(isolated function() returns string {
+                return "Failed to invalidate JWT from the cache. JWT payload: " + jwtPayload;
             });
         }
     }
@@ -128,14 +129,15 @@ isolated function validateFromCache(cache:Cache jwtCache, string jwt) returns Jw
 
 isolated function addToCache(cache:Cache jwtCache, string jwt, JwtPayload payload) {
     cache:Error? result = jwtCache.put(jwt, payload);
+    final string jwtPayload = payload.toString();
     if (result is cache:Error) {
-        log:printDebug(function() returns string {
-            return "Failed to add JWT to the cache. JWT payload: " + payload.toString();
+        log:printDebug(isolated function() returns string {
+            return "Failed to add JWT to the cache. JWT payload: " + jwtPayload;
         });
         return;
     }
-    log:printDebug(function() returns string {
-        return "JWT added to the cache. JWT payload: " + payload.toString();
+    log:printDebug(isolated function() returns string {
+        return "JWT added to the cache. JWT payload: " + jwtPayload;
     });
 }
 
@@ -430,8 +432,9 @@ isolated function getJwk(string kid, JwksConfig jwksConfig) returns @tainted (js
             if (jwk is json) {
                 return jwk;
             } else {
-                log:printDebug(function() returns string {
-                    return "Failed to retrieve JWK for the kid: " + kid + " from the cache";
+                final string kidValue = kid;
+                log:printDebug(isolated function() returns string {
+                    return "Failed to retrieve JWK for the kid: " + kidValue + " from the cache";
                 });
             }
         }

--- a/jwt-ballerina/src/jwt/jwt_validator.bal
+++ b/jwt-ballerina/src/jwt/jwt_validator.bal
@@ -110,35 +110,25 @@ public function validateJwt(string jwt, JwtValidatorConfig config) returns @tain
 isolated function validateFromCache(cache:Cache jwtCache, string jwt) returns JwtPayload? {
     JwtPayload payload = <JwtPayload>jwtCache.get(jwt);
     int? expTime = payload?.exp;
-    final string jwtPayload = payload.toString();
     // convert to current time and check the expiry time
     if (expTime is () || expTime > (time:currentTime().time / 1000)) {
-        log:printDebug(isolated function() returns string {
-            return "JWT validated from the cache. JWT payload: " + jwtPayload;
-        });
+        log:printDebug("JWT validated from the cache. JWT payload: " + payload.toString());
         return payload;
     } else {
         cache:Error? result = jwtCache.invalidate(jwt);
         if (result is cache:Error) {
-            log:printDebug(isolated function() returns string {
-                return "Failed to invalidate JWT from the cache. JWT payload: " + jwtPayload;
-            });
+            log:printDebug("Failed to invalidate JWT from the cache. JWT payload: " + payload.toString());
         }
     }
 }
 
 isolated function addToCache(cache:Cache jwtCache, string jwt, JwtPayload payload) {
     cache:Error? result = jwtCache.put(jwt, payload);
-    final string jwtPayload = payload.toString();
     if (result is cache:Error) {
-        log:printDebug(isolated function() returns string {
-            return "Failed to add JWT to the cache. JWT payload: " + jwtPayload;
-        });
+        log:printDebug("Failed to add JWT to the cache. JWT payload: " + payload.toString());
         return;
     }
-    log:printDebug(isolated function() returns string {
-        return "JWT added to the cache. JWT payload: " + jwtPayload;
-    });
+    log:printDebug("JWT added to the cache. JWT payload: " + payload.toString());
 }
 
 # Decodes the given JWT string.
@@ -432,10 +422,7 @@ isolated function getJwk(string kid, JwksConfig jwksConfig) returns json|Error {
             if (jwk is json) {
                 return jwk;
             } else {
-                final string kidValue = kid;
-                log:printDebug(isolated function() returns string {
-                    return "Failed to retrieve JWK for the kid: " + kidValue + " from the cache";
-                });
+                log:printDebug("Failed to retrieve JWK for the kid: " + kid + " from the cache");
             }
         }
     }

--- a/jwt-ballerina/src/jwt/jwt_validator.bal
+++ b/jwt-ballerina/src/jwt/jwt_validator.bal
@@ -46,6 +46,7 @@ public type JwtValidatorConfig record {|
 #
 # + url - URL of the JWKs endpoint
 # + jwksCache - Cache used to store preloaded JWKs information
+# + clientConfig - HTTP client configurations which calls the JWKs endpoint
 public type JwksConfig record {|
     string url;
     cache:Cache jwksCache?;

--- a/jwt-ballerina/src/jwt/jwt_validator.bal
+++ b/jwt-ballerina/src/jwt/jwt_validator.bal
@@ -49,6 +49,31 @@ public type JwtValidatorConfig record {|
 public type JwksConfig record {|
     string url;
     cache:Cache jwksCache?;
+    ClientConfiguration clientConfig = {};
+|};
+
+# Represents the configurations of the client used to call the JWKs endpoint.
+#
+# + httpVersion - The HTTP version of the client
+# + secureSocket - SSL/TLS related configurations
+public type ClientConfiguration record {|
+    HttpVersion httpVersion = HTTP_1_1;
+    SecureSocket secureSocket?;
+|};
+
+# Represents HTTP versions.
+public enum HttpVersion {
+    HTTP_1_1,
+    HTTP_2
+}
+
+# Represents the SSL/TLS configurations.
+#
+# + disable - Disable SSL validation
+# + trustStore - Configurations associated with TrustStore
+public type SecureSocket record {|
+    boolean disable = false;
+    crypto:TrustStore trustStore?;
 |};
 
 # Represents JWT trust store configurations.
@@ -410,7 +435,7 @@ isolated function getJwk(string kid, JwksConfig jwksConfig) returns @tainted (js
             }
         }
     }
-    string|Error stringResponse = getJwksResponse(jwksConfig.url);
+    string|Error stringResponse = getJwksResponse(jwksConfig.url, jwksConfig.clientConfig);
     if (stringResponse is Error) {
         return prepareError("Failed to call JWKs endpoint.", stringResponse);
     }
@@ -432,7 +457,7 @@ isolated function getJwksArray(string stringResponse) returns json[]|Error {
     return jwks;
 }
 
-isolated function getJwksResponse(string url) returns string|Error = @java:Method {
+isolated function getJwksResponse(string url, ClientConfiguration clientConfig) returns string|Error = @java:Method {
     'class: "org.ballerinalang.stdlib.jwt.JwksClient"
 } external;
 

--- a/jwt-ballerina/src/jwt/tests/unit-tests/jwt-issuer-and-validator-test.bal
+++ b/jwt-ballerina/src/jwt/tests/unit-tests/jwt-issuer-and-validator-test.bal
@@ -474,3 +474,89 @@ function testValidateJwtWithInvalidSignature() {
         test:assertFail(msg = errMsg is string ? errMsg : "Error in validating JWT");
     }
 }
+
+@test:Config {
+    dependsOn: ["testValidateJwtWithInvalidSignature"]
+}
+function testValidateJwtSignatureWithJwk() {
+    string jwt = "eyJhbGciOiJSUzI1NiIsICJ0eXAiOiJKV1QiLCAia2lkIjoiTlRBeFptTXhORE15WkRnM01UVTFaR00wTXpFek9ESmhaV0k0Tk" +
+                 "RObFpEVTFPR0ZrTmpGaU1RIn0.eyJzdWIiOiJhZG1pbiIsICJpc3MiOiJiYWxsZXJpbmEiLCAiZXhwIjoxOTA3NjY1NzQ2LCAi" +
+                 "anRpIjoiMTAwMDc4MjM0YmEyMyIsICJhdWQiOlsidkV3emJjYXNKVlFtMWpWWUhVSENqaHhaNHRZYSJdfQ.E8E7VO18V6MG7Ns" +
+                 "87Y314Dqg8RYOMe0WWYlSYFhSv0mHkJQ8bSSyBJzFG0Se_7UsTWFBwzIALw6wUiP7UGraosilf8k6HGJWbTjWtLXfniJXx5Ncz" +
+                 "ikzciG8ADddksm-0AMi5uPsgAQdg7FNaH9f4vAL6SPMEYp2gN6GDnWTH7M1vnknwjOwTbQpGrPu_w2V1tbsBwSzof3Fk_cYrnt" +
+                 "u8D_pfsBu3eqFiJZD7AXUq8EYbgIxpSwvdi6_Rvw2_TAi46drouxXK2Jglz_HvheUVCERT15Y8JNJONJPJ52MsN6t297hyFV9A" +
+                 "myNPzwHxxmi753TclbapDqDnVPI1tpc-Q";
+    JwtValidatorConfig config = {
+        issuer: "ballerina",
+        audience: "vEwzbcasJVQm1jVYHUHCjhxZ4tYa",
+        jwksConfig: {
+            url: "https://asb0zigfg2.execute-api.us-west-2.amazonaws.com/v1/jwks"
+        }
+    };
+    var result = validateJwt(jwt, config);
+    if !(result is JwtPayload) {
+        string? errMsg = result.message();
+        test:assertFail(msg = errMsg is string ? errMsg : "Error in validating JWT");
+    }
+}
+
+@test:Config {
+    dependsOn: ["testValidateJwtSignatureWithJwk"]
+}
+function testValidateJwtSignatureWithInvalidJwk() {
+    // There is a JWK with the same `kid`, but the `modulus` of the public key does not match.
+    string jwt = "eyJ4NXQiOiJOVEF4Wm1NeE5ETXlaRGczTVRVMVpHTTBNekV6T0RKaFpXSTRORE5sWkRVMU9HRmtOakZpTVEiLCJraWQiO" +
+             "iJOVEF4Wm1NeE5ETXlaRGczTVRVMVpHTTBNekV6T0RKaFpXSTRORE5sWkRVMU9HRmtOakZpTVEiLCJhbGciOiJSUzI1NiJ9.ey" +
+             "JzdWIiOiJhZG1pbkBjYXJib24uc3VwZXIiLCJhdWQiOiJ2RXd6YmNhc0pWUW0xalZZSFVIQ2poeFo0dFlhIiwibmJmIjoxNTg3" +
+             "NDc1Njk0LCJhenAiOiJ2RXd6YmNhc0pWUW0xalZZSFVIQ2poeFo0dFlhIiwiaXNzIjoiaHR0cHM6XC9cL2xvY2FsaG9zdDo5ND" +
+             "QzXC9vYXV0aDJcL3Rva2VuIiwiZXhwIjoxNTg3NDc1NzA0LCJpYXQiOjE1ODc0NzU2OTQsImp0aSI6ImZmMTk3NmI0LTU0MmYt" +
+             "NDgxNC1iOGNlLTg0ODNhNGYxZWE5ZiJ9.VHXgtU72omIibSfwuggIXhykivfAncUFF5-mCCrrVwRBNWpd2KEVBqizGU_onCdNo" +
+             "SsJOc608d-2Tq77ZzJkq7RXPRTxdim4lHkL9PgJpuJzbbk7-c9z3Zd10Kd7n_BuiiUCqJxQQTvfwAShjl6pHd-Z6bqBTdIPDBg" +
+             "hJnTmGgEydWDBzvl8zsUPZJAUFHLlKUBIW8Qy0tC7NpUnPWyYoXdFf0hpkQi0h58fTG9iMr-30mlFJgBRjsanbBQEemWXokZ6T" +
+             "uam1DQAQB9-Tsxk1TQ5GRyMKcsD2gWt-aJsyRLtXSwmgsUxTyA6VCLlF9oJuMxg-hQKxiDS1RSXHReczw";
+    JwtValidatorConfig config = {
+        issuer: "ballerina",
+        audience: "vEwzbcasJVQm1jVYHUHCjhxZ4tYa",
+        jwksConfig: {
+            url: "https://asb0zigfg2.execute-api.us-west-2.amazonaws.com/v1/jwks"
+        }
+    };
+    var result = validateJwt(jwt, config);
+    if !(result is Error) {
+        test:assertFail(msg = "Error in validating JWT with invalid JWK");
+    }
+}
+
+@test:Config {
+    dependsOn: ["testValidateJwtSignatureWithInvalidJwk"]
+}
+function testValidateJwtSignatureWithJwkWithClientConfig() {
+    string jwt = "eyJhbGciOiJSUzI1NiIsICJ0eXAiOiJKV1QiLCAia2lkIjoiTlRBeFptTXhORE15WkRnM01UVTFaR00wTXpFek9ESmhaV0k0Tk" +
+                 "RObFpEVTFPR0ZrTmpGaU1RIn0.eyJzdWIiOiJhZG1pbiIsICJpc3MiOiJiYWxsZXJpbmEiLCAiZXhwIjoxOTA3NjY1NzQ2LCAi" +
+                 "anRpIjoiMTAwMDc4MjM0YmEyMyIsICJhdWQiOlsidkV3emJjYXNKVlFtMWpWWUhVSENqaHhaNHRZYSJdfQ.E8E7VO18V6MG7Ns" +
+                 "87Y314Dqg8RYOMe0WWYlSYFhSv0mHkJQ8bSSyBJzFG0Se_7UsTWFBwzIALw6wUiP7UGraosilf8k6HGJWbTjWtLXfniJXx5Ncz" +
+                 "ikzciG8ADddksm-0AMi5uPsgAQdg7FNaH9f4vAL6SPMEYp2gN6GDnWTH7M1vnknwjOwTbQpGrPu_w2V1tbsBwSzof3Fk_cYrnt" +
+                 "u8D_pfsBu3eqFiJZD7AXUq8EYbgIxpSwvdi6_Rvw2_TAi46drouxXK2Jglz_HvheUVCERT15Y8JNJONJPJ52MsN6t297hyFV9A" +
+                 "myNPzwHxxmi753TclbapDqDnVPI1tpc-Q";
+    JwtValidatorConfig config = {
+        issuer: "ballerina",
+        audience: "vEwzbcasJVQm1jVYHUHCjhxZ4tYa",
+        jwksConfig: {
+            url: "https://asb0zigfg2.execute-api.us-west-2.amazonaws.com/v1/jwks",
+            clientConfig: {
+                httpVersion: HTTP_2,
+                secureSocket: {
+                    trustStore: {
+                        path: TRUSTSTORE_PATH,
+                        password: "ballerina"
+                    }
+                }
+            }
+        }
+    };
+    var result = validateJwt(jwt, config);
+    if !(result is JwtPayload) {
+        string? errMsg = result.message();
+        test:assertFail(msg = errMsg is string ? errMsg : "Error in validating JWT with client configurations");
+    }
+}

--- a/jwt-native/build.gradle
+++ b/jwt-native/build.gradle
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+plugins {
+    id 'java'
+}
+
+description = 'Ballerina - JWT Java Utils'
+
+dependencies {
+    compile group: 'org.ballerinalang', name: 'ballerina-runtime', version: "${ballerinaLangVersion}"
+}
+
+compileJava {
+    doFirst {
+        options.compilerArgs = [
+                '--module-path', classpath.asPath,
+        ]
+        classpath = files()
+    }
+}

--- a/jwt-native/src/main/java/module-info.java
+++ b/jwt-native/src/main/java/module-info.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+module io.ballerina.stdlib.jwt {
+    requires io.ballerina.runtime;
+    requires java.net.http;
+    exports org.ballerinalang.stdlib.jwt;
+}

--- a/jwt-native/src/main/java/org/ballerinalang/stdlib/jwt/Constants.java
+++ b/jwt-native/src/main/java/org/ballerinalang/stdlib/jwt/Constants.java
@@ -1,0 +1,14 @@
+package org.ballerinalang.stdlib.jwt;
+
+import io.ballerina.runtime.api.Module;
+
+import static io.ballerina.runtime.api.constants.RuntimeConstants.BALLERINA_BUILTIN_PKG_PREFIX;
+
+/**
+ * Constants related to Ballerina jwt stdlib.
+ */
+public class Constants {
+    public static final String PACKAGE_NAME = "jwt";
+    public static final Module JWT_PACKAGE_ID = new Module(BALLERINA_BUILTIN_PKG_PREFIX, PACKAGE_NAME, "1.0.4");
+    public static final String JWT_ERROR_TYPE = "JwtError";
+}

--- a/jwt-native/src/main/java/org/ballerinalang/stdlib/jwt/Constants.java
+++ b/jwt-native/src/main/java/org/ballerinalang/stdlib/jwt/Constants.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.ballerinalang.stdlib.jwt;
 
 import io.ballerina.runtime.api.Module;
@@ -5,7 +23,7 @@ import io.ballerina.runtime.api.Module;
 import static io.ballerina.runtime.api.constants.RuntimeConstants.BALLERINA_BUILTIN_PKG_PREFIX;
 
 /**
- * Constants related to Ballerina jwt stdlib.
+ * Constants related to Ballerina JWT stdlib.
  */
 public class Constants {
     public static final String PACKAGE_NAME = "jwt";

--- a/jwt-native/src/main/java/org/ballerinalang/stdlib/jwt/Constants.java
+++ b/jwt-native/src/main/java/org/ballerinalang/stdlib/jwt/Constants.java
@@ -29,4 +29,15 @@ public class Constants {
     public static final String PACKAGE_NAME = "jwt";
     public static final Module JWT_PACKAGE_ID = new Module(BALLERINA_BUILTIN_PKG_PREFIX, PACKAGE_NAME, "1.0.4");
     public static final String JWT_ERROR_TYPE = "JwtError";
+
+    public static final String HTTP_VERSION = "httpVersion";
+    public static final String DISABLE = "disable";
+    public static final String SECURE_SOCKET = "secureSocket";
+    public static final String TRUSTSTORE = "trustStore";
+    public static final String PATH = "path";
+    public static final String PASSWORD = "password";
+
+    public static final String TLS = "TLS";
+    public static final String PKCS12 = "PKCS12";
+    public static final String HTTP_2 = "HTTP_2";
 }

--- a/jwt-native/src/main/java/org/ballerinalang/stdlib/jwt/JwksClient.java
+++ b/jwt-native/src/main/java/org/ballerinalang/stdlib/jwt/JwksClient.java
@@ -152,7 +152,7 @@ public class JwksClient {
 
     private static BMap<?, ?> getMapValueIfPresent(BMap<BString, Object> config, String key) {
         return config.containsKey(StringUtils.fromString(key)) ?
-                config.getMapValue(StringUtils.fromString(Constants.SECURE_SOCKET)) : null;
+                config.getMapValue(StringUtils.fromString(key)) : null;
     }
 
     private static BError createError(String errMsg) {

--- a/jwt-native/src/main/java/org/ballerinalang/stdlib/jwt/JwksClient.java
+++ b/jwt-native/src/main/java/org/ballerinalang/stdlib/jwt/JwksClient.java
@@ -21,34 +21,129 @@ package org.ballerinalang.stdlib.jwt;
 import io.ballerina.runtime.api.creators.ErrorCreator;
 import io.ballerina.runtime.api.utils.StringUtils;
 import io.ballerina.runtime.api.values.BError;
+import io.ballerina.runtime.api.values.BMap;
 import io.ballerina.runtime.api.values.BString;
 
+import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.security.KeyManagementException;
+import java.security.KeyStore;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.security.cert.X509Certificate;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.TrustManagerFactory;
+import javax.net.ssl.X509TrustManager;
 
 /**
  * Extern function to call JWKs endpoint and get the response.
  */
 public class JwksClient {
 
-    public static Object getJwksResponse(BString url) {
-        HttpClient client = HttpClient.newBuilder().version(HttpClient.Version.HTTP_1_1).build();
-        HttpRequest request = HttpRequest.newBuilder().uri(URI.create(url.getValue())).build();
+    public static Object getJwksResponse(BString url, BMap<BString, Object> clientConfig) {
+        String httpVersion = clientConfig.getStringValue(StringUtils.fromString("httpVersion")).getValue();
+        BMap<BString, Object> secureSocket = clientConfig.containsKey(StringUtils.fromString("secureSocket")) ?
+                (BMap<BString, Object>) clientConfig.getMapValue(StringUtils.fromString("secureSocket")) : null;
+        if (secureSocket != null) {
+            boolean disable = secureSocket.getBooleanValue(StringUtils.fromString("disable"));
+            if (disable) {
+                try {
+                    SSLContext sslContext = initSslContext();
+                    HttpClient client = buildHttpClient(httpVersion, sslContext);
+                    return callJwksEndpoint(client, url.getValue());
+                } catch (NoSuchAlgorithmException | KeyManagementException e) {
+                    return createError("Failed to init SSL context. " + e.getMessage());
+                }
+            }
+            BMap<BString, Object> trustStore = secureSocket.containsKey(StringUtils.fromString("trustStore")) ?
+                    (BMap<BString, Object>) secureSocket.getMapValue(StringUtils.fromString("trustStore")) : null;
+            if (trustStore != null) {
+                try {
+                    SSLContext sslContext = initSslContext(trustStore);
+                    HttpClient client = buildHttpClient(httpVersion, sslContext);
+                    return callJwksEndpoint(client, url.getValue());
+                } catch (Exception e) {
+                    return createError("Failed to init SSL context with truststore. " + e.getMessage());
+                }
+            }
+        }
+        HttpClient client = buildHttpClient(httpVersion);
+        return callJwksEndpoint(client, url.getValue());
+    }
+
+    private static HttpClient.Version getHttpVersion(String httpVersion) {
+        if ("HTTP_2".equals(httpVersion)) {
+            return HttpClient.Version.HTTP_2;
+        }
+        return HttpClient.Version.HTTP_1_1;
+    }
+
+    private static SSLContext initSslContext() throws NoSuchAlgorithmException, KeyManagementException {
+        TrustManager[] trustAllCerts = new TrustManager[]{
+                new X509TrustManager() {
+                    public X509Certificate[] getAcceptedIssuers() {
+                        return null;
+                    }
+
+                    public void checkClientTrusted(X509Certificate[] certs, String authType) {
+                    }
+
+                    public void checkServerTrusted(X509Certificate[] certs, String authType) {
+                    }
+                }
+        };
+        SSLContext sslContext = SSLContext.getInstance("TLS");
+        sslContext.init(null, trustAllCerts, new SecureRandom());
+        return sslContext;
+    }
+
+    private static SSLContext initSslContext(BMap<BString, Object> trustStore) throws Exception {
+        String path = trustStore.getStringValue(StringUtils.fromString("path")).getValue();
+        String password = trustStore.getStringValue(StringUtils.fromString("password")).getValue();
+        InputStream is = new FileInputStream(new File(path));
+        char[] passphrase = password.toCharArray();
+        KeyStore ks = KeyStore.getInstance("PKCS12");
+        ks.load(is, passphrase);
+        KeyManagerFactory kmf = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+        kmf.init(ks, passphrase);
+        TrustManagerFactory tmf = TrustManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+        tmf.init(ks);
+        SSLContext sslContext = SSLContext.getInstance("TLS");
+        sslContext.init(kmf.getKeyManagers(), tmf.getTrustManagers(), new SecureRandom());
+        return sslContext;
+    }
+
+    private static HttpClient buildHttpClient(String httpVersion, SSLContext sslContext) {
+        return HttpClient.newBuilder().version(getHttpVersion(httpVersion)).sslContext(sslContext).build();
+    }
+
+    private static HttpClient buildHttpClient(String httpVersion) {
+        return HttpClient.newBuilder().version(getHttpVersion(httpVersion)).build();
+    }
+
+    private static Object callJwksEndpoint(HttpClient client, String url) {
+        HttpRequest request = HttpRequest.newBuilder().uri(URI.create(url)).build();
         try {
             HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
             if (response.statusCode() == 200) {
                 return StringUtils.fromString(response.body());
             }
-            return createError("Failed to get success response from JWKs endpoint.");
+            return createError("Failed to get a success response from JWKs endpoint. Response Code: " +
+                                       response.statusCode());
         } catch (IOException | InterruptedException e) {
-            return createError(e.getMessage());
+            return createError("Failed to send the request to JWKs endpoint. " + e.getMessage());
         }
     }
 
-    public static BError createError(String errMsg) {
+    private static BError createError(String errMsg) {
         return ErrorCreator.createDistinctError(Constants.JWT_ERROR_TYPE, Constants.JWT_PACKAGE_ID,
                                                 StringUtils.fromString(errMsg));
     }

--- a/jwt-native/src/main/java/org/ballerinalang/stdlib/jwt/JwksClient.java
+++ b/jwt-native/src/main/java/org/ballerinalang/stdlib/jwt/JwksClient.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.ballerinalang.stdlib.jwt;
+
+import io.ballerina.runtime.api.creators.ErrorCreator;
+import io.ballerina.runtime.api.utils.StringUtils;
+import io.ballerina.runtime.api.values.BError;
+import io.ballerina.runtime.api.values.BString;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+/**
+ * Extern function to call JWKs endpoint and get the response.
+ */
+public class JwksClient {
+
+    public static Object getJwks(BString url) {
+        HttpClient client = HttpClient.newBuilder().version(HttpClient.Version.HTTP_1_1).build();
+        HttpRequest request = HttpRequest.newBuilder().uri(URI.create(url.getValue())).build();
+        try {
+            HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+            if (response.statusCode() == 200) {
+                return StringUtils.fromString(response.body());
+            }
+            return createError("Failed to get success response from JWKs endpoint.");
+        } catch (IOException | InterruptedException e) {
+            return createError(e.getMessage());
+        }
+    }
+
+    public static BError createError(String errMsg) {
+        return ErrorCreator.createDistinctError(Constants.JWT_ERROR_TYPE, Constants.JWT_PACKAGE_ID,
+                                                StringUtils.fromString(errMsg));
+    }
+}

--- a/jwt-native/src/main/java/org/ballerinalang/stdlib/jwt/JwksClient.java
+++ b/jwt-native/src/main/java/org/ballerinalang/stdlib/jwt/JwksClient.java
@@ -112,12 +112,10 @@ public class JwksClient {
         char[] passphrase = password.toCharArray();
         KeyStore ks = KeyStore.getInstance(Constants.PKCS12);
         ks.load(is, passphrase);
-        KeyManagerFactory kmf = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
-        kmf.init(ks, passphrase);
         TrustManagerFactory tmf = TrustManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
         tmf.init(ks);
         SSLContext sslContext = SSLContext.getInstance(Constants.TLS);
-        sslContext.init(kmf.getKeyManagers(), tmf.getTrustManagers(), new SecureRandom());
+        sslContext.init(null, tmf.getTrustManagers(), new SecureRandom());
         return sslContext;
     }
 
@@ -144,7 +142,7 @@ public class JwksClient {
                 return StringUtils.fromString(response.body());
             }
             return createError("Failed to get a success response from JWKs endpoint. Response Code: " +
-                                       response.statusCode());
+                                       response.statusCode() + ". Response Body: " + response.body());
         } catch (IOException | InterruptedException e) {
             return createError("Failed to send the request to JWKs endpoint. " + e.getMessage());
         }

--- a/jwt-native/src/main/java/org/ballerinalang/stdlib/jwt/JwksClient.java
+++ b/jwt-native/src/main/java/org/ballerinalang/stdlib/jwt/JwksClient.java
@@ -49,11 +49,12 @@ import javax.net.ssl.X509TrustManager;
 public class JwksClient {
 
     public static Object getJwksResponse(BString url, BMap<BString, Object> clientConfig) {
-        String httpVersion = clientConfig.getStringValue(StringUtils.fromString("httpVersion")).getValue();
-        BMap<BString, Object> secureSocket = clientConfig.containsKey(StringUtils.fromString("secureSocket")) ?
-                (BMap<BString, Object>) clientConfig.getMapValue(StringUtils.fromString("secureSocket")) : null;
+        String httpVersion = clientConfig.getStringValue(StringUtils.fromString(Constants.HTTP_VERSION)).getValue();
+        BMap<BString, Object> secureSocket = clientConfig.containsKey(StringUtils.fromString(Constants.SECURE_SOCKET)) ?
+                (BMap<BString, Object>) clientConfig.getMapValue(StringUtils.fromString(Constants.SECURE_SOCKET)) :
+                null;
         if (secureSocket != null) {
-            boolean disable = secureSocket.getBooleanValue(StringUtils.fromString("disable"));
+            boolean disable = secureSocket.getBooleanValue(StringUtils.fromString(Constants.DISABLE));
             if (disable) {
                 try {
                     SSLContext sslContext = initSslContext();
@@ -63,8 +64,9 @@ public class JwksClient {
                     return createError("Failed to init SSL context. " + e.getMessage());
                 }
             }
-            BMap<BString, Object> trustStore = secureSocket.containsKey(StringUtils.fromString("trustStore")) ?
-                    (BMap<BString, Object>) secureSocket.getMapValue(StringUtils.fromString("trustStore")) : null;
+            BMap<BString, Object> trustStore = secureSocket.containsKey(StringUtils.fromString(Constants.TRUSTSTORE)) ?
+                    (BMap<BString, Object>) secureSocket.getMapValue(StringUtils.fromString(Constants.TRUSTSTORE)) :
+                    null;
             if (trustStore != null) {
                 try {
                     SSLContext sslContext = initSslContext(trustStore);
@@ -80,7 +82,7 @@ public class JwksClient {
     }
 
     private static HttpClient.Version getHttpVersion(String httpVersion) {
-        if ("HTTP_2".equals(httpVersion)) {
+        if (Constants.HTTP_2.equals(httpVersion)) {
             return HttpClient.Version.HTTP_2;
         }
         return HttpClient.Version.HTTP_1_1;
@@ -100,23 +102,23 @@ public class JwksClient {
                     }
                 }
         };
-        SSLContext sslContext = SSLContext.getInstance("TLS");
+        SSLContext sslContext = SSLContext.getInstance(Constants.TLS);
         sslContext.init(null, trustAllCerts, new SecureRandom());
         return sslContext;
     }
 
     private static SSLContext initSslContext(BMap<BString, Object> trustStore) throws Exception {
-        String path = trustStore.getStringValue(StringUtils.fromString("path")).getValue();
-        String password = trustStore.getStringValue(StringUtils.fromString("password")).getValue();
+        String path = trustStore.getStringValue(StringUtils.fromString(Constants.PATH)).getValue();
+        String password = trustStore.getStringValue(StringUtils.fromString(Constants.PASSWORD)).getValue();
         InputStream is = new FileInputStream(new File(path));
         char[] passphrase = password.toCharArray();
-        KeyStore ks = KeyStore.getInstance("PKCS12");
+        KeyStore ks = KeyStore.getInstance(Constants.PKCS12);
         ks.load(is, passphrase);
         KeyManagerFactory kmf = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
         kmf.init(ks, passphrase);
         TrustManagerFactory tmf = TrustManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
         tmf.init(ks);
-        SSLContext sslContext = SSLContext.getInstance("TLS");
+        SSLContext sslContext = SSLContext.getInstance(Constants.TLS);
         sslContext.init(kmf.getKeyManagers(), tmf.getTrustManagers(), new SecureRandom());
         return sslContext;
     }

--- a/jwt-native/src/main/java/org/ballerinalang/stdlib/jwt/JwksClient.java
+++ b/jwt-native/src/main/java/org/ballerinalang/stdlib/jwt/JwksClient.java
@@ -34,7 +34,7 @@ import java.net.http.HttpResponse;
  */
 public class JwksClient {
 
-    public static Object getJwks(BString url) {
+    public static Object getJwksResponse(BString url) {
         HttpClient client = HttpClient.newBuilder().version(HttpClient.Version.HTTP_1_1).build();
         HttpRequest request = HttpRequest.newBuilder().uri(URI.create(url.getValue())).build();
         try {

--- a/settings.gradle
+++ b/settings.gradle
@@ -13,7 +13,7 @@ plugins {
 
 rootProject.name = 'jwt'
 include(':build-config:checkstyle')
-include ':jwt-ballerina'
+include ':jwt-native', ':jwt-ballerina'
 
 gradleEnterprise {
     buildScan {


### PR DESCRIPTION
## Purpose
JWT module uses `ballerina/http` client to call JWKs endpoint. This PR replace the `ballerina/http` client and all the usages with the JDK11 HTTP client.

Fixes: https://github.com/ballerina-platform/ballerina-standard-library/issues/579