### PR TITLE
Add Codecov Report Generation

### DIFF
--- a/.github/workflows/build-master.yml
+++ b/.github/workflows/build-master.yml
@@ -38,6 +38,8 @@ jobs:
           name: Code Coverage JSON
           path: jwt-ballerina/target/report/test_results.json
           if-no-files-found: ignore
+      - name: Generate Codecov Report
+        uses: codecov/codecov-action@v1
       - name: Dispatch Dependent Module Builds
         if: github.event.action != 'stdlib-publish-snapshot'
         run: |

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -33,6 +33,8 @@ jobs:
           name: Code Coverage JSON
           path: jwt-ballerina/target/report/test_results.json
           if-no-files-found: ignore
+      - name: Generate Codecov Report
+        uses: codecov/codecov-action@v1
 
   windows-build:
     runs-on: windows-latest

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,5 +1,6 @@
 codecov:
   require_ci_to_pass: no
+  notify.wait_for_ci: no
 
 fixes:
   - "ballerina/jwt/*/::jwt-ballerina/"

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,7 +1,3 @@
-codecov:
-  require_ci_to_pass: no
-  notify.wait_for_ci: no
-
 fixes:
   - "ballerina/jwt/*/::jwt-ballerina/"
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,9 @@
+codecov:
+  require_ci_to_pass: no
+
+fixes:
+  - "ballerina/jwt/*/::jwt-ballerina/"
+
+ignore:
+  - "**/tests"
+

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,6 @@
+codecov:
+  require_ci_to_pass: no
+
 fixes:
   - "ballerina/jwt/*/::jwt-ballerina/"
 


### PR DESCRIPTION
## Purpose
- Introducing `Codecov` code coverage report publishing to the `jwt` repository

## Goals
- Publishing the testerina generated code coverage xml to `Codecov` triggered via GitHub action of PR.

## Approach
- A new job is inserted to `Pull request` and `Build` GitHub actions that publishes the XML report to  `Codecov`.
- These jobs trigger on push or pull request and `CodeCov` generates a descriptive code coverage report.
- `Codecov` also adds comments to any PR made based on the code coverage changes between commits

## Test environment
> Ubuntu 20.04
