### PR TITLE
Add cert file and mTLS support for JDK11 client

### DIFF
--- a/jwt-ballerina/jwt_validator.bal
+++ b/jwt-ballerina/jwt_validator.bal
@@ -74,10 +74,23 @@ public enum HttpVersion {
 # Represents the SSL/TLS configurations.
 #
 # + disable - Disable SSL validation
-# + trustStore - Configurations associated with TrustStore
+# + cert - Configurations associated with `crypto:TrustStore` or single certificate file that the client trusts
+# + key - Configurations associated with `crypto:KeyStore` or combination of certificate and private key of the client
 public type SecureSocket record {|
     boolean disable = false;
-    crypto:TrustStore trustStore?;
+    crypto:TrustStore|string cert;
+    crypto:KeyStore|CertKey key?;
+|};
+
+# Represents combination of certificate, private key and private key password if encrypted.
+#
+# + certFile - A file containing the certificate
+# + keyFile - A file containing the private key
+# + keyPassword - Password of the private key if it is encrypted
+public type CertKey record {|
+   string certFile;
+   string keyFile;
+   string keyPassword?;
 |};
 
 # Validates the provided JWT, against the provided configurations.

--- a/jwt-ballerina/tests/jwt_issuer_and_validator_test.bal
+++ b/jwt-ballerina/tests/jwt_issuer_and_validator_test.bal
@@ -561,7 +561,7 @@ isolated function testValidateJwtSignatureWithJwkWithClientInvalidCertificate() 
     };
     Payload|Error result = validate(jwt, validatorConfig);
     if (result is Error) {
-        test:assertEquals(buildCompleteErrorMessage(result), "Failed to call JWKs endpoint. Failed to send the request to JWKs endpoint. PKIX path building failed: sun.security.provider.certpath.SunCertPathBuilderException: unable to find valid certification path to requested target");
+        test:assertEquals(buildCompleteErrorMessage(result), "Failed to call JWKs endpoint. Failed to send the request to the endpoint. PKIX path building failed: sun.security.provider.certpath.SunCertPathBuilderException: unable to find valid certification path to requested target");
     } else {
         test:assertFail(msg = "Error in validating JWT signature with invalid certificate.");
     }

--- a/jwt-ballerina/tests/jwt_issuer_and_validator_test.bal
+++ b/jwt-ballerina/tests/jwt_issuer_and_validator_test.bal
@@ -502,7 +502,7 @@ isolated function testValidateJwtSignatureWithInvalidJwk() {
 }
 
 @test:Config {}
-isolated function testValidateJwtSignatureWithJwkWithClientConfig() {
+isolated function testValidateJwtSignatureWithJwkWithValidTrustStore() {
     string jwt = "eyJhbGciOiJSUzI1NiIsICJ0eXAiOiJKV1QiLCAia2lkIjoiTlRBeFptTXhORE15WkRnM01UVTFaR00wTXpFek9ESmhaV0k0Tk" +
                  "RObFpEVTFPR0ZrTmpGaU1RIn0.eyJzdWIiOiJhZG1pbiIsICJpc3MiOiJiYWxsZXJpbmEiLCAiZXhwIjoxOTA3NjY1NzQ2LCAi" +
                  "anRpIjoiMTAwMDc4MjM0YmEyMyIsICJhdWQiOlsidkV3emJjYXNKVlFtMWpWWUhVSENqaHhaNHRZYSJdfQ.E8E7VO18V6MG7Ns" +
@@ -519,7 +519,7 @@ isolated function testValidateJwtSignatureWithJwkWithClientConfig() {
                 clientConfig: {
                     httpVersion: HTTP_2,
                     secureSocket: {
-                        trustStore: {
+                        cert: {
                             path: TRUSTSTORE_PATH,
                             password: "ballerina"
                         }
@@ -532,6 +532,38 @@ isolated function testValidateJwtSignatureWithJwkWithClientConfig() {
     if (result is Error) {
         string? errMsg = result.message();
         test:assertFail(msg = errMsg is string ? errMsg : "Error in validating JWT with client configurations.");
+    }
+}
+
+@test:Config {}
+isolated function testValidateJwtSignatureWithJwkWithClientInvalidCertificate() {
+    string jwt = "eyJhbGciOiJSUzI1NiIsICJ0eXAiOiJKV1QiLCAia2lkIjoiTlRBeFptTXhORE15WkRnM01UVTFaR00wTXpFek9ESmhaV0k0Tk" +
+                 "RObFpEVTFPR0ZrTmpGaU1RIn0.eyJzdWIiOiJhZG1pbiIsICJpc3MiOiJiYWxsZXJpbmEiLCAiZXhwIjoxOTA3NjY1NzQ2LCAi" +
+                 "anRpIjoiMTAwMDc4MjM0YmEyMyIsICJhdWQiOlsidkV3emJjYXNKVlFtMWpWWUhVSENqaHhaNHRZYSJdfQ.E8E7VO18V6MG7Ns" +
+                 "87Y314Dqg8RYOMe0WWYlSYFhSv0mHkJQ8bSSyBJzFG0Se_7UsTWFBwzIALw6wUiP7UGraosilf8k6HGJWbTjWtLXfniJXx5Ncz" +
+                 "ikzciG8ADddksm-0AMi5uPsgAQdg7FNaH9f4vAL6SPMEYp2gN6GDnWTH7M1vnknwjOwTbQpGrPu_w2V1tbsBwSzof3Fk_cYrnt" +
+                 "u8D_pfsBu3eqFiJZD7AXUq8EYbgIxpSwvdi6_Rvw2_TAi46drouxXK2Jglz_HvheUVCERT15Y8JNJONJPJ52MsN6t297hyFV9A" +
+                 "myNPzwHxxmi753TclbapDqDnVPI1tpc-Q";
+    ValidatorConfig validatorConfig = {
+        issuer: "ballerina",
+        audience: "vEwzbcasJVQm1jVYHUHCjhxZ4tYa",
+        signatureConfig: {
+            jwksConfig: {
+                url: "https://asb0zigfg2.execute-api.us-west-2.amazonaws.com/v1/jwks",
+                clientConfig: {
+                    httpVersion: HTTP_2,
+                    secureSocket: {
+                        cert: PUBLIC_CERT_PATH
+                    }
+                }
+            }
+        }
+    };
+    Payload|Error result = validate(jwt, validatorConfig);
+    if (result is Error) {
+        test:assertEquals(buildCompleteErrorMessage(result), "Failed to call JWKs endpoint. Failed to send the request to JWKs endpoint. PKIX path building failed: sun.security.provider.certpath.SunCertPathBuilderException: unable to find valid certification path to requested target");
+    } else {
+        test:assertFail(msg = "Error in validating JWT signature with invalid certificate.");
     }
 }
 

--- a/jwt-ballerina/tests/test_utils.bal
+++ b/jwt-ballerina/tests/test_utils.bal
@@ -20,3 +20,14 @@ const string PRIVATE_KEY_PATH = "tests/resources/key/private.key";
 const string ENCRYPTED_PRIVATE_KEY_PATH = "tests/resources/key/encryptedPrivate.key";
 const string PUBLIC_CERT_PATH = "tests/resources/cert/public.crt";
 const string INVALID_PUBLIC_CERT_PATH = "tests/resources/cert/invalidPublic.crt";
+
+// Build complete error message by evaluating all the inner causes.
+isolated function buildCompleteErrorMessage(error err) returns string {
+    string message = err.message();
+    error? cause = err.cause();
+    while (cause is error) {
+        message += " " + cause.message();
+        cause = cause.cause();
+    }
+    return message;
+}

--- a/jwt-native/build.gradle
+++ b/jwt-native/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     checkstyle "com.puppycrawl.tools:checkstyle:${puppycrawlCheckstyleVersion}"
 
     compile group: 'org.ballerinalang', name: 'ballerina-runtime', version: "${ballerinaLangVersion}"
+    compile group: 'org.ballerinalang', name: 'crypto-native', version: "${stdlibCryptoVersion}"
 }
 
 checkstyle {

--- a/jwt-native/src/main/java/module-info.java
+++ b/jwt-native/src/main/java/module-info.java
@@ -18,5 +18,6 @@
 module io.ballerina.stdlib.jwt {
     requires io.ballerina.runtime;
     requires java.net.http;
+    requires io.ballerina.stdlib.crypto;
     exports org.ballerinalang.stdlib.jwt;
 }

--- a/jwt-native/src/main/java/org/ballerinalang/stdlib/jwt/JwtConstants.java
+++ b/jwt-native/src/main/java/org/ballerinalang/stdlib/jwt/JwtConstants.java
@@ -18,20 +18,30 @@
 
 package org.ballerinalang.stdlib.jwt;
 
+import io.ballerina.runtime.api.utils.StringUtils;
+import io.ballerina.runtime.api.values.BString;
+
 /**
  * Constants related to Ballerina JWT stdlib.
  */
 public class JwtConstants {
     public static final String JWT_ERROR_TYPE = "JwtError";
 
-    public static final String HTTP_VERSION = "httpVersion";
-    public static final String DISABLE = "disable";
-    public static final String SECURE_SOCKET = "secureSocket";
-    public static final String TRUSTSTORE = "trustStore";
-    public static final String PATH = "path";
-    public static final String PASSWORD = "password";
+    public static final BString HTTP_VERSION = StringUtils.fromString("httpVersion");
+    public static final BString SECURE_SOCKET = StringUtils.fromString("secureSocket");
+    public static final BString DISABLE = StringUtils.fromString("disable");
+    public static final BString CERT = StringUtils.fromString("cert");
+    public static final BString KEY = StringUtils.fromString("key");
+    public static final BString CERT_FILE = StringUtils.fromString("certFile");
+    public static final BString KEY_FILE = StringUtils.fromString("keyFile");
+    public static final BString KEY_PASSWORD = StringUtils.fromString("keyPassword");
+    public static final BString PATH = StringUtils.fromString("path");
+    public static final BString PASSWORD = StringUtils.fromString("password");
 
     public static final String TLS = "TLS";
     public static final String PKCS12 = "PKCS12";
     public static final String HTTP_2 = "HTTP_2";
+
+    public static final String NATIVE_DATA_PUBLIC_KEY_CERTIFICATE = "NATIVE_DATA_PUBLIC_KEY_CERTIFICATE";
+    public static final String NATIVE_DATA_PRIVATE_KEY = "NATIVE_DATA_PRIVATE_KEY";
 }


### PR DESCRIPTION
## Purpose
This PR add cert file and mTLS support for JDK11 client secure socket configurations. The updated configuration is
```ballerina
public type SecureSocket record {|
    boolean disable = false;
    crypto:TrustStore|string cert;
    crypto:KeyStore|CertKey key?;
|};

public type CertKey record {|
   string certFile;
   string keyFile;
   string keyPassword?;
|};
```

Fixes https://github.com/ballerina-platform/ballerina-standard-library/issues/936
Related to https://github.com/ballerina-platform/ballerina-standard-library/issues/584