### PR TITLE
Add HMAC signature support for JWT

### DIFF
--- a/ballerina/jwt_commons.bal
+++ b/ballerina/jwt_commons.bal
@@ -17,7 +17,7 @@
 import ballerina/jballerina.java;
 
 # Represents the cryptographic algorithms used to secure the JWS.
-public type SigningAlgorithm RS256|RS384|RS512|NONE;
+public type SigningAlgorithm RS256|RS384|RS512|HS256|HS384|HS512|NONE;
 
 # The `RSA-SHA256` algorithm.
 public const RS256 = "RS256";
@@ -27,6 +27,15 @@ public const RS384 = "RS384";
 
 # The `RSA-SHA512` algorithm.
 public const RS512 = "RS512";
+
+# The `HMAC-SHA256` algorithm.
+public const HS256 = "HS256";
+
+# The `HMAC-SHA384` algorithm.
+public const HS384 = "HS384";
+
+# The `HMAC-SHA512` algorithm.
+public const HS512 = "HS512";
 
 # Unsecured JWS (no signing).
 public const NONE = "none";

--- a/ballerina/tests/jwt_issuer_test.bal
+++ b/ballerina/tests/jwt_issuer_test.bal
@@ -312,6 +312,81 @@ isolated function testIssueJwtWithSigningAlgorithmRS512() {
 }
 
 @test:Config {}
+isolated function testIssueJwtWithSigningAlgorithmHS256() {
+    IssuerConfig issuerConfig = {
+        username: "John",
+        issuer: "wso2",
+        audience: ["ballerina", "ballerinaSamples"],
+        expTime: 600,
+        signatureConfig: {
+            algorithm: HS256,
+            config: "s3cr3t"
+        }
+    };
+
+    string|Error result = issue(issuerConfig);
+    if (result is string) {
+        test:assertTrue(result.startsWith("eyJhbGciOiJIUzI1NiIsICJ0eXAiOiJKV1QifQ."));
+        string header = "{\"alg\":\"HS256\", \"typ\":\"JWT\"}";
+        string payload = "{\"iss\":\"wso2\", \"sub\":\"John\", \"aud\":[\"ballerina\", \"ballerinaSamples\"]";
+        assertDecodedJwt(result, header, payload);
+    } else {
+        string? errMsg = result.message();
+        test:assertFail(msg = errMsg is string ? errMsg : "Error in generated JWT.");
+    }
+}
+
+@test:Config {}
+isolated function testIssueJwtWithSigningAlgorithmHS384() {
+    IssuerConfig issuerConfig = {
+        username: "John",
+        issuer: "wso2",
+        audience: ["ballerina", "ballerinaSamples"],
+        expTime: 600,
+        signatureConfig: {
+            algorithm: HS384,
+            config: "s3cr3t"
+        }
+    };
+
+    string|Error result = issue(issuerConfig);
+    if (result is string) {
+        test:assertTrue(result.startsWith("eyJhbGciOiJIUzM4NCIsICJ0eXAiOiJKV1QifQ."));
+        string header = "{\"alg\":\"HS384\", \"typ\":\"JWT\"}";
+        string payload = "{\"iss\":\"wso2\", \"sub\":\"John\", \"aud\":[\"ballerina\", \"ballerinaSamples\"]";
+        assertDecodedJwt(result, header, payload);
+    } else {
+        string? errMsg = result.message();
+        test:assertFail(msg = errMsg is string ? errMsg : "Error in generated JWT.");
+    }
+}
+
+@test:Config {}
+isolated function testIssueJwtWithSigningAlgorithmHS512() {
+    IssuerConfig issuerConfig = {
+        username: "John",
+        issuer: "wso2",
+        audience: ["ballerina", "ballerinaSamples"],
+        expTime: 600,
+        signatureConfig: {
+            algorithm: HS512,
+            config: "s3cr3t"
+        }
+    };
+
+    string|Error result = issue(issuerConfig);
+    if (result is string) {
+        test:assertTrue(result.startsWith("eyJhbGciOiJIUzUxMiIsICJ0eXAiOiJKV1QifQ."));
+        string header = "{\"alg\":\"HS512\", \"typ\":\"JWT\"}";
+        string payload = "{\"iss\":\"wso2\", \"sub\":\"John\", \"aud\":[\"ballerina\", \"ballerinaSamples\"]";
+        assertDecodedJwt(result, header, payload);
+    } else {
+        string? errMsg = result.message();
+        test:assertFail(msg = errMsg is string ? errMsg : "Error in generated JWT.");
+    }
+}
+
+@test:Config {}
 isolated function testIssueJwtWithoutSigningKeyInformation() {
     IssuerConfig issuerConfig = {
         username: "John",

--- a/ballerina/tests/jwt_validator_test.bal
+++ b/ballerina/tests/jwt_validator_test.bal
@@ -619,3 +619,90 @@ isolated function testValidateJwtSignatureWithInvalidPublicCert() {
         test:assertFail(msg = "Error in validating JWT.");
     }
 }
+
+@test:Config {}
+isolated function testValidateJwtSignatureWithHS256SharedSecret() {
+    ValidatorConfig validatorConfig = {
+        issuer: "wso2",
+        audience: ["ballerina", "ballerinaSamples"],
+        clockSkew: 60,
+        signatureConfig: {
+            secret: "s3cr3t"
+        }
+    };
+    Payload|Error result = validate(JWT6, validatorConfig);
+    if (result is Error) {
+        string? errMsg = result.message();
+        test:assertFail(msg = errMsg is string ? errMsg : "Error in validating JWT.");
+    }
+}
+
+@test:Config {}
+isolated function testValidateJwtSignatureWithHS384SharedSecret() {
+    ValidatorConfig validatorConfig = {
+        issuer: "wso2",
+        audience: ["ballerina", "ballerinaSamples"],
+        clockSkew: 60,
+        signatureConfig: {
+            secret: "s3cr3t"
+        }
+    };
+    Payload|Error result = validate(JWT7, validatorConfig);
+    if (result is Error) {
+        string? errMsg = result.message();
+        test:assertFail(msg = errMsg is string ? errMsg : "Error in validating JWT.");
+    }
+}
+
+@test:Config {}
+isolated function testValidateJwtSignatureWithHS512SharedSecret() {
+    ValidatorConfig validatorConfig = {
+        issuer: "wso2",
+        audience: ["ballerina", "ballerinaSamples"],
+        clockSkew: 60,
+        signatureConfig: {
+            secret: "s3cr3t"
+        }
+    };
+    Payload|Error result = validate(JWT8, validatorConfig);
+    if (result is Error) {
+        string? errMsg = result.message();
+        test:assertFail(msg = errMsg is string ? errMsg : "Error in validating JWT.");
+    }
+}
+
+@test:Config {}
+isolated function testValidateJwtSignatureWithInvalidSharedSecret() {
+    ValidatorConfig validatorConfig = {
+        issuer: "wso2",
+        audience: ["ballerina", "ballerinaSamples"],
+        clockSkew: 60,
+        signatureConfig: {
+            secret: "!nva1id"
+        }
+    };
+    Payload|Error result = validate(JWT6, validatorConfig);
+    if (result is Error) {
+        assertContains(result, "JWT signature validation with shared secret has failed.");
+    } else {
+        test:assertFail(msg = "Error in validating JWT.");
+    }
+}
+
+@test:Config {}
+isolated function testValidateJwtSignatureWithInvalidAlgorithm() {
+    ValidatorConfig validatorConfig = {
+        issuer: "wso2",
+        audience: ["ballerina", "ballerinaSamples"],
+        clockSkew: 60,
+        signatureConfig: {
+            certFile: PUBLIC_CERT_PATH
+        }
+    };
+    Payload|Error result = validate(JWT6, validatorConfig);
+    if (result is Error) {
+        assertContains(result, "Unsupported RSA algorithm 'HS256'.");
+    } else {
+        test:assertFail(msg = "Error in validating JWT.");
+    }
+}

--- a/ballerina/tests/test_utils.bal
+++ b/ballerina/tests/test_utils.bal
@@ -137,6 +137,64 @@ const string JWT5 = "eyJhbGciOiJSUzI1NiIsICJ0eXAiOiJKV1QiLCAia2lkIjoiNWEwYjc1NC0
                     "t4flzCBsTGWC7XZaFnwT4mUlX7WpTOgv1Nsq5GVLszvsnzs6BE__Mvr4zl5pdChVbkMXX3US6fYguK268XKjzgtpMVxUpL3" +
                     "CrzwQpIRyI-Q";
 
+// {
+//  "alg": "HS256",
+//  "typ": "JWT"
+// }
+// {
+//  "iss": "wso2",
+//  "sub": "John",
+//  "aud": [
+//    "ballerina",
+//    "ballerinaSamples"
+//  ],
+//  "exp": 1943255429,
+//  "nbf": 1627895429,
+//  "iat": 1627895429
+// }
+const string JWT6 = "eyJhbGciOiJIUzI1NiIsICJ0eXAiOiJKV1QifQ.eyJpc3MiOiJ3c28yIiwgInN1YiI6IkpvaG4iLCAiYXVkIjpbImJhbGxl" +
+                    "cmluYSIsICJiYWxsZXJpbmFTYW1wbGVzIl0sICJleHAiOjE5NDMyNTU0MjksICJuYmYiOjE2Mjc4OTU0MjksICJpYXQiOjE" +
+                    "2Mjc4OTU0Mjl9.BqFvZtKFj4KiVGkSkbXAcG4mpmSnGM0f60GYMw7dj4k";
+
+// {
+//  "alg": "HS384",
+//  "typ": "JWT"
+// }
+// {
+//  "iss": "wso2",
+//  "sub": "John",
+//  "aud": [
+//    "ballerina",
+//    "ballerinaSamples"
+//  ],
+//  "exp": 1943257494,
+//  "nbf": 1627897494,
+//  "iat": 1627897494
+// }
+const string JWT7 = "eyJhbGciOiJIUzM4NCIsICJ0eXAiOiJKV1QifQ.eyJpc3MiOiJ3c28yIiwgInN1YiI6IkpvaG4iLCAiYXVkIjpbImJhbGxl" +
+                    "cmluYSIsICJiYWxsZXJpbmFTYW1wbGVzIl0sICJleHAiOjE5NDMyNTc0OTQsICJuYmYiOjE2Mjc4OTc0OTQsICJpYXQiOjE" +
+                    "2Mjc4OTc0OTR9.gwyn7kbaX-AQi0SQQmPoKfazehSsr7XUTnxewKny2qcOOVJrIqlLVyCoyacFlPel";
+
+// {
+//  "alg": "HS512",
+//  "typ": "JWT"
+// }
+// {
+//  "iss": "wso2",
+//  "sub": "John",
+//  "aud": [
+//    "ballerina",
+//    "ballerinaSamples"
+//  ],
+//  "exp": 1627899452,
+//  "nbf": 1627898852,
+//  "iat": 1627898852
+// }
+const string JWT8 = "eyJhbGciOiJIUzUxMiIsICJ0eXAiOiJKV1QifQ.eyJpc3MiOiJ3c28yIiwgInN1YiI6IkpvaG4iLCAiYXVkIjpbImJhbGxl" +
+                    "cmluYSIsICJiYWxsZXJpbmFTYW1wbGVzIl0sICJleHAiOjE2Mjc4OTk0NTIsICJuYmYiOjE2Mjc4OTg4NTIsICJpYXQiOjE" +
+                    "2Mjc4OTg4NTJ9.Y-71DT1OnESuDkXmzParDgJ_iJ65DqTGvT3aNj1GVPJaHV8UPpD44O3nAgrXGFXpszWmeMoPz99BmUAHA" +
+                    "azszA";
+
 // Builds the complete error message by evaluating all the inner causes and asserts the inclusion.
 isolated function assertContains(error err, string text) {
     string message = err.message();

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased]
 
 ### Added
+- [Add HMAC signature support for JWT](https://github.com/ballerina-platform/ballerina-standard-library/issues/1645)
+
+## [1.1.0-beta2] - 2021-07-06
+
+### Added
 - [Improve JWT validation for all the fields of JWT issuer configuration](https://github.com/ballerina-platform/ballerina-standard-library/issues/1240)
 
 ## [1.1.0-alpha8] - 2021-04-22


### PR DESCRIPTION
## Purpose
This PR adds the HMAC signature support for JWT according to the Section-3.2 of RFC 7518 [1].

```
The following "alg" (algorithm) Header Parameter values are used to
indicate that the JWS Signature is an HMAC value computed using the
corresponding algorithm:

             +-------------------+--------------------+
             | "alg" Param Value | MAC Algorithm      |
             +-------------------+--------------------+
             | HS256             | HMAC using SHA-256 |
             | HS384             | HMAC using SHA-384 |
             | HS512             | HMAC using SHA-512 |
             +-------------------+--------------------+
```

[1] https://datatracker.ietf.org/doc/html/rfc7518#section-3.2

## Examples

**Sample Issuer Config**
```ballerina
jwt:IssuerConfig issuerConfig = {
    username: "John",
    issuer: "wso2",
    audience: ["ballerina", "ballerinaSamples"],
    expTime: 600,
    signatureConfig: {
        algorithm: jwt:HS256,
        config: "s3cr3t"
    }
};
```

**Sample Validator Config**
```ballerina
jwt:ValidatorConfig validatorConfig = {
    issuer: "wso2",
    audience: ["ballerina", "ballerinaSamples"],
    clockSkew: 60,
    signatureConfig: {
        secret: "s3cr3t"
    }
};
```

Fixes https://github.com/ballerina-platform/ballerina-standard-library/issues/1645

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [x] Added tests
