### PR TITLE
Revert support to directly provide `crypto:PrivateKey` and `crypto:PublicKey` in JWT signature configurations

### DIFF
--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "jwt"
-version = "2.12.0"
+version = "2.12.1"
 authors = ["Ballerina"]
 keywords = ["security", "authentication", "jwt", "jwk", "jws"]
 repository = "https://github.com/ballerina-platform/module-ballerina-jwt"
@@ -15,5 +15,5 @@ graalvmCompatible = true
 [[platform.java17.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "jwt-native"
-version = "2.12.0"
-path = "../native/build/libs/jwt-native-2.12.0.jar"
+version = "2.12.1"
+path = "../native/build/libs/jwt-native-2.12.1-SNAPSHOT.jar"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -49,9 +49,6 @@ dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.value"}
 ]
-modules = [
-	{org = "ballerina", packageName = "io", moduleName = "io"}
-]
 
 [[package]]
 org = "ballerina"
@@ -64,11 +61,10 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "jwt"
-version = "2.12.0"
+version = "2.12.1"
 dependencies = [
 	{org = "ballerina", name = "cache"},
 	{org = "ballerina", name = "crypto"},
-	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.int"},
 	{org = "ballerina", name = "lang.string"},

--- a/ballerina/jwt_issuer.bal
+++ b/ballerina/jwt_issuer.bal
@@ -41,7 +41,7 @@ public type IssuerConfig record {|
 # Represents JWT signature configurations.
 #
 # + algorithm - Cryptographic signing algorithm for JWS
-# + config - KeyStore configurations, private key configurations, `crypto:PrivateKey` or shared key configurations
+# + config - KeyStore configurations, private key configurations or shared key configurations
 public type IssuerSignatureConfig record {|
     SigningAlgorithm algorithm = RS256;
     record {|
@@ -51,7 +51,7 @@ public type IssuerSignatureConfig record {|
     |} | record {|
         string keyFile;
         string keyPassword?;
-    |} | crypto:PrivateKey | string config?;
+    |} | string config?;
 |};
 
 # Issues a JWT based on the provided configurations. JWT will be signed (JWS) if `crypto:KeyStore` information is
@@ -93,8 +93,6 @@ public isolated function issue(IssuerConfig issuerConfig) returns string|Error {
         } else {
             return prepareError("Failed to decode private key.", privateKey);
         }
-    } else if config is crypto:PrivateKey {
-        return signJwtAssertion(jwtAssertion, algorithm, config);
     } else {
         string keyFile = <string> config?.keyFile;
         string? keyPassword = config?.keyPassword;

--- a/ballerina/jwt_validator.bal
+++ b/ballerina/jwt_validator.bal
@@ -48,7 +48,7 @@ public type ValidatorConfig record {
 # Represents JWT signature configurations.
 #
 # + jwksConfig - JWKS configurations
-# + certFile - Public certificate file path or a `crypto:PublicKey`
+# + certFile - Public certificate file path
 # + trustStoreConfig - JWT TrustStore configurations
 # + secret - HMAC secret configuration
 public type ValidatorSignatureConfig record {|
@@ -57,7 +57,7 @@ public type ValidatorSignatureConfig record {|
         cache:CacheConfig cacheConfig?;
         ClientConfiguration clientConfig = {};
     |} jwksConfig?;
-    string|crypto:PublicKey certFile?;
+    string certFile?;
     record {|
         crypto:TrustStore trustStore;
         string certAlias;
@@ -331,13 +331,8 @@ isolated function validateSignature(string jwt, Header header, Payload payload, 
             } else {
                 return prepareError("Key ID (kid) is not provided in JOSE header.");
             }
-        } else if certFile !is () {
-            crypto:PublicKey|crypto:Error publicKey;
-            if certFile is crypto:PublicKey {
-                publicKey = certFile;
-            } else {
-                publicKey = crypto:decodeRsaPublicKeyFromCertFile(certFile);
-            }
+        } else if certFile is string {
+            crypto:PublicKey|crypto:Error publicKey = crypto:decodeRsaPublicKeyFromCertFile(certFile);
             if publicKey is crypto:PublicKey {
                 if !validateCertificate(publicKey) {
                    return prepareError("Public key certificate validity period has passed.");

--- a/ballerina/tests/jwt_issuer_test.bal
+++ b/ballerina/tests/jwt_issuer_test.bal
@@ -16,8 +16,6 @@
 
 // NOTE: All the tokens/credentials used in this test are dummy tokens/credentials and used only for testing purposes.
 
-import ballerina/crypto;
-import ballerina/io;
 import ballerina/lang.'string;
 import ballerina/test;
 
@@ -359,44 +357,6 @@ isolated function testIssueJwtWithEncryptedPrivateKey() returns Error? {
                 keyFile: ENCRYPTED_PRIVATE_KEY_PATH,
                 keyPassword: "ballerina"
             }
-        }
-    };
-    string result = check issue(issuerConfig);
-    string expectedHeader = "{\"alg\":\"RS256\", \"typ\":\"JWT\"}";
-    string expectedPayload = "{\"iss\":\"wso2\", \"sub\":\"John\", \"aud\":[\"ballerina\", \"ballerinaSamples\"]";
-    assertDecodedJwt(result, expectedHeader, expectedPayload);
-}
-
-@test:Config {}
-isolated function testIssueJwtWithCryptoPrivateKey() returns io:Error|crypto:Error|Error? {
-    byte[] privateKeyContent = check io:fileReadBytes(PRIVATE_KEY_PATH);
-    crypto:PrivateKey privateKey = check crypto:decodeRsaPrivateKeyFromContent(privateKeyContent);
-    IssuerConfig issuerConfig = {
-        username: "John",
-        issuer: "wso2",
-        audience: ["ballerina", "ballerinaSamples"],
-        expTime: 600,
-        signatureConfig: {
-            config: privateKey
-        }
-    };
-    string result = check issue(issuerConfig);
-    string expectedHeader = "{\"alg\":\"RS256\", \"typ\":\"JWT\"}";
-    string expectedPayload = "{\"iss\":\"wso2\", \"sub\":\"John\", \"aud\":[\"ballerina\", \"ballerinaSamples\"]";
-    assertDecodedJwt(result, expectedHeader, expectedPayload);
-}
-
-@test:Config {}
-isolated function testIssueJwtWithEncryptedCryptoPrivateKey() returns io:Error|crypto:Error|Error? {
-    byte[] privateKeyContent = check io:fileReadBytes(ENCRYPTED_PRIVATE_KEY_PATH);
-    crypto:PrivateKey encryptedPrivateKey = check crypto:decodeRsaPrivateKeyFromContent(privateKeyContent, "ballerina");
-    IssuerConfig issuerConfig = {
-        username: "John",
-        issuer: "wso2",
-        audience: ["ballerina", "ballerinaSamples"],
-        expTime: 600,
-        signatureConfig: {
-            config: encryptedPrivateKey
         }
     };
     string result = check issue(issuerConfig);

--- a/ballerina/tests/jwt_validator_test.bal
+++ b/ballerina/tests/jwt_validator_test.bal
@@ -16,8 +16,6 @@
 
 // NOTE: All the tokens/credentials used in this test are dummy tokens/credentials and used only for testing purposes.
 
-import ballerina/crypto;
-import ballerina/io;
 import ballerina/test;
 
 @test:Config {}
@@ -689,22 +687,6 @@ isolated function testValidateJwtSignatureWithPublicCert() returns Error? {
         clockSkew: 60,
         signatureConfig: {
             certFile: PUBLIC_CERT_PATH
-        }
-    };
-    Payload result = check validate(JWT1, validatorConfig);
-    test:assertEquals(result?.iss, "wso2");
-}
-
-@test:Config {}
-isolated function testValidateJwtSignatureWithCryptoPublicKey() returns io:Error|crypto:Error|Error? {
-    byte[] pubicCertContent = check io:fileReadBytes(PUBLIC_CERT_PATH);
-    crypto:PublicKey publicKey = check crypto:decodeRsaPublicKeyFromContent(pubicCertContent);
-    ValidatorConfig validatorConfig = {
-        issuer: "wso2",
-        audience: ["ballerina", "ballerinaSamples"],
-        clockSkew: 60,
-        signatureConfig: {
-            certFile: publicKey
         }
     };
     Payload result = check validate(JWT1, validatorConfig);

--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+## Changed
+- [Revert support to directly provide `crypto:PrivateKey` and `crypto:PublicKey` in JWT signature configurations](https://github.com/ballerina-platform/ballerina-library/issues/6628)
+
+## [2.12.0] - 2024-05-31
+
 ### Added
 - [Add support to directly provide `crypto:PrivateKey` and `crypto:PublicKey` in JWT signature configurations](https://github.com/ballerina-platform/ballerina-library/issues/6514)
 

--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -104,7 +104,7 @@ public type ValidatorSignatureConfig record {|
         cache:CacheConfig cacheConfig?;
         ClientConfiguration clientConfig = {};
     |} jwksConfig?;
-    string|crypto:PublicKey certFile?;
+    string certFile?;
     record {|
         crypto:TrustStore trustStore;
         string certAlias;
@@ -222,7 +222,7 @@ public type IssuerSignatureConfig record {|
     |}|record {|
         string keyFile;
         string keyPassword?;
-    |}|crypto:PrivateKey|string config?;
+    |}|string config?;
 |};
 
 public class ClientSelfSignedJwtAuthProvider {


### PR DESCRIPTION
## Purpose
> $subject

Reverts: [#1229](https://github.com/ballerina-platform/module-ballerina-jwt/pull/1229)

Fixes: [#6628](https://github.com/ballerina-platform/ballerina-library/issues/6628)

## Examples
N/A

## Checklist
- [X] Linked to an issue
- [X] Updated the changelog
- [ ] ~Added tests~
- [x] Updated the spec
- [ ] ~Checked native-image compatibility~
